### PR TITLE
Added autocomplete.sh setup

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -129,6 +129,30 @@ RUN echo "" >> ~/.bashrc && \
 	  echo "" >> ~/.bashrc
 
 ###########################################################################
+# Autocomplete
+###########################################################################
+
+USER root
+
+COPY ./autocomplete.sh /root/autocomplete.sh
+COPY ./autocomplete.sh /home/laradock/autocomplete.sh
+
+RUN sed -i 's/\r//' /root/autocomplete.sh && \
+    sed -i 's/\r//' /home/laradock/autocomplete.sh && \
+    chown laradock:laradock /home/laradock/autocomplete.sh && \
+    echo "" >> ~/.bashrc && \
+    echo "# Load Autocompletion" >> ~/.bashrc && \
+    echo "source ~/autocomplete.sh" >> ~/.bashrc && \
+    echo "" >> ~/.bashrc
+    
+USER laradock
+
+RUN echo "" >> ~/.bashrc && \
+    echo "# Load Autocompletion" >> ~/.bashrc && \
+    echo "source ~/autocomplete.sh" >> ~/.bashrc && \
+	  echo "" >> ~/.bashrc
+
+###########################################################################
 # Composer:
 ###########################################################################
 

--- a/workspace/autocomplete.sh
+++ b/workspace/autocomplete.sh
@@ -1,0 +1,12 @@
+# Laravel artisan autocomplete
+_artisan()
+{
+	COMP_WORDBREAKS=${COMP_WORDBREAKS//:}
+	COMMANDS=`php artisan --raw --no-ansi list | sed "s/[[:space:]].*//g"`
+	COMPREPLY=(`compgen -W "$COMMANDS" -- "${COMP_WORDS[COMP_CWORD]}"`)
+	return 0
+}
+complete -F _artisan art
+complete -F _artisan artisan
+
+# Add other autocomplete scripts here


### PR DESCRIPTION
## Description
Added an `autocomplete.sh` to the workspace and set it up just like `aliases.sh`. The user can now enjoy built-in Laravel artisan autocompletion. Additionally the user can add own autocompletion scripts.

## Motivation and Context
Usage of Laravel's `astisan` is much more comfortable with autocompletion.

## Types of Changes
- [] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
